### PR TITLE
Fix trait on beta fission gun

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -614,6 +614,9 @@
     "techLevel": 5,
     "traits": [
       {
+        "type": "energy"
+      },
+      {
         "type": "burn",
         "amount": 2
       },


### PR DESCRIPTION
Add Missing `Energy` Trait on Beta Fission Gun. 